### PR TITLE
Fix: Context don't update after patch request

### DIFF
--- a/src/app/dashboard/edit-map-marker/[id]/page.tsx
+++ b/src/app/dashboard/edit-map-marker/[id]/page.tsx
@@ -7,17 +7,21 @@ import { useSession } from "next-auth/react";
 import { useState, useEffect } from "react";
 import { toast } from "sonner";
 
-import { getMapMarkerById } from "@/requests/get";
-import { ScreenContentDefault } from "../../components/ScreenContentDefault";
-import { GetMaps } from "@/requests/get/map-markers/types";
-import { MapMarkerEditor } from "../../components/map-marker/MapMarkerEditor";
 import { updateMapMarker } from "@/requests/patch/map-markers";
 import { PatchMaps } from "@/requests/patch/map-markers/types";
+import { GetMaps } from "@/requests/get/map-markers/types";
+import { getMapMarkerById } from "@/requests/get";
+
+import { ScreenContentDefault } from "../../components/ScreenContentDefault";
+import { MapMarkerEditor } from "../../components/map-marker/MapMarkerEditor";
 import Loading from "@/components/loading";
+
 import { useLoading } from "@/hooks/use-loading";
+import { useMapMarkers } from "@/hooks/use-map-markers";
 
 const EditMapMarker = () => {
   const { data: session } = useSession({ required: true });
+  const { mapMarkers, setMapMarkers } = useMapMarkers();
 
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
@@ -62,6 +66,25 @@ const EditMapMarker = () => {
       if (!response.ok) {
         throw new Error((await response.json()).message);
       }
+
+      const oldMapMarker = mapMarkers.find((e) => e._id === mapMarkerData._id);
+
+      if (oldMapMarker) {
+        setMapMarkers([
+          ...mapMarkers.filter((e) => e._id !== mapMarkerData._id),
+          {
+            _id: oldMapMarker._id,
+            latitude: Number(data.latitude),
+            longitude: Number(data.longitude),
+            review: {
+              _id: data.reviewId,
+              thumbnail: oldMapMarker.review.thumbnail,
+              headline: oldMapMarker.review.headline,
+            },
+          },
+        ]);
+      }
+
 
       toast.success("Map marker updated", {
         description: "Your map marker has been successfully updated.",

--- a/src/app/dashboard/edit-review/[id]/page.tsx
+++ b/src/app/dashboard/edit-review/[id]/page.tsx
@@ -83,7 +83,7 @@ const EditReview = () => {
           country: data.country,
           city: data.city,
           claps: data.claps,
-          createdAt: data.createdAt,
+          createdAt: reviews.find((e) => e._id === reviewData._id)?.createdAt ?? "",
           priceRating: Number(data.priceRating),
           tags: data.tags,
         },

--- a/src/app/dashboard/new-review/page.tsx
+++ b/src/app/dashboard/new-review/page.tsx
@@ -2,18 +2,24 @@
 
 "use client";
 
+import { useSession } from "next-auth/react";
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";
+
 import { ReviewEditor } from "../components/review/ReviewEditor";
 import { ScreenContentDefault } from "../components/ScreenContentDefault";
+
 import { createReview } from "@/requests/post";
-import { useSession } from "next-auth/react";
 import { GetReviews } from "@/requests/get/reviews/types";
+
 import Loading from "@/components/loading";
+
 import { useLoading } from "@/hooks/use-loading";
+import { useReviews } from "@/hooks/use-reviews";
 
 const NewReview = () => {
   const { isLoading, setIsLoading } = useLoading();
+  const { reviews, setReviews } = useReviews();
   const router = useRouter();
 
   const { data: session, status } = useSession({ required: true });
@@ -30,6 +36,26 @@ const NewReview = () => {
       if (!response.ok) {
         throw new Error();
       }
+
+      const responseData = await response.json();
+
+      setReviews([
+        ...reviews,
+        {
+          _id: responseData.data._id,
+          thumbnail: data.thumbnail,
+          headline: data.headline,
+          friendlyUrl: data.friendlyUrl,
+          rating: data.rating,
+          claps: data.claps,
+          address: data.address,
+          country: data.country,
+          city: data.city,
+          createdAt: data.createdAt,
+          priceRating: data.priceRating,
+          tags: data.tags,
+        }
+      ]);
 
       toast.success("Review created", {
         description: "Your review has been successfully created.",

--- a/src/app/dashboard/tags/page.tsx
+++ b/src/app/dashboard/tags/page.tsx
@@ -75,11 +75,10 @@ const Reviews = () => {
           throw new Error((await response.json()).message);
         }
 
-        const oldTags = tags.filter((tag) => tag._id !== e._id);
         const responseJson = (await response.json()).data;
 
         setTags([
-          ...oldTags,
+          ...tags,
           {
             _id: responseJson._id,
             name: e.name,


### PR DESCRIPTION
# 🚀 Fix: Context don't update after patch request 

Enhance Map Marker and Review Management Functionality

## 📖 Description

- **What’s changing?**  
  This PR introduces two primary enhancements: improving the state management for map markers and reviews and ensuring data consistency across the application.

- **Why?**  
  The motivation behind this PR is to enhance the user experience by providing real-time updates for map markers and reviews. This is achieved by updating the local state immediately after server interactions, ensuring the UI reflects the current data without requiring a full page reload.

## 🛠 Implementation Details

- Integrated the `useMapMarkers` hook to manage map marker states more effectively.
- Updated the `edit-map-marker` component to reflect map marker updates in real-time by adjusting the local list of markers.
- Updated the `new-review` component to add new reviews directly to the local state, ensuring immediate UI reflection.
- Added the `useReviews` hook to manage review states effectively and ensure seamless updates to the reviews list.
- Fixed an inconsistency by ensuring that the `createdAt` field in the `edit-review` component maintains its original value unless explicitly changed.

## 📊 Queries changed

- Enhanced the map marker update functionality to adjust the in-memory marker collection after a successful update.
- Amended the process of handling new reviews so that the local state is updated with the newly created review.

## ⚙️ New envs

None.

## 🔗 Related Issues / Tickets

None.