### PR TITLE
Feat: Add refetch in hooks to use pagination

### DIFF
--- a/src/hooks/use-map-markers.ts
+++ b/src/hooks/use-map-markers.ts
@@ -7,21 +7,28 @@ import { getMapMarkers } from "@/requests/get";
 export function useMapMarkers() {
   const [mapMarkers, setMapMarkersAtom] = useAtom(mapMarkersAtom);
 
+  const setMapMarkers = useCallback((newValue: GetMaps.MapMarker[] | null) => {
+    setMapMarkersAtom(newValue);
+  }, [setMapMarkersAtom]);
+
+
   useEffect(() => {
-    if (mapMarkers === null) { 
-    getMapMarkers({ page: 1, limit: 15 }).then((fetched) => {
+    if (mapMarkers === null) {
+      getMapMarkers({ page: 1, limit: 15 }).then((fetched) => {
         setMapMarkers(fetched);
       });
     }
-  }, [mapMarkers]);
+  }, [mapMarkers, setMapMarkers]);
 
-  const setMapMarkers = useCallback((newValue: GetMaps.MapMarker[] | null) => {
-    setMapMarkersAtom(newValue);
+  const refetchMapMarkers = useCallback(async ({ page, limit }: { page: number; limit: number }) => {
+    const fetched = await getMapMarkers({ page, limit });
+    setMapMarkersAtom(Array.isArray(fetched) ? fetched : []);
   }, [setMapMarkersAtom]);
 
   return {
     mapMarkers: mapMarkers ?? [],
     loading: mapMarkers === null,
-    setMapMarkers
+    setMapMarkers,
+    refetchMapMarkers
   };
 }

--- a/src/hooks/use-reviews.ts
+++ b/src/hooks/use-reviews.ts
@@ -10,19 +10,30 @@ export function useReviews() {
   const [reviews, setReviewsAtom] = useAtom(reviewsAtom);
   const loading = reviews === null;
 
+  const setReviews = useCallback((newValue: GetReviews.ReviewListItem[] | null) => {
+    setReviewsAtom(newValue);
+  }, [setReviewsAtom]);
+
+
   useEffect(() => {
     if (reviews === null) {
-      getReviews(1, 20).then((fetched) => {
+      getReviews({ page: 1, limit: 20 }).then((fetched) => {
         if (Array.isArray(fetched)) {
           setReviews(fetched);
         }
       });
     }
-  }, [reviews]);
+  }, [reviews, setReviews]);
 
-  const setReviews = useCallback((newValue: GetReviews.ReviewListItem[] | null) => {
-    setReviewsAtom(newValue);
+  const refetchReviews = useCallback(async ({ page, limit }: { page: number; limit: number }) => {
+    const fetched = await getReviews({ page, limit });
+    setReviewsAtom(Array.isArray(fetched) ? fetched : []);
   }, [setReviewsAtom]);
 
-  return { reviews: reviews ?? [], loading, setReviews };
+  return {
+    reviews: reviews ?? [],
+    loading,
+    setReviews,
+    refetchReviews
+  };
 }

--- a/src/hooks/use-tags.ts
+++ b/src/hooks/use-tags.ts
@@ -12,16 +12,26 @@ export function useTags() {
 
   useEffect(() => {
     if (tags === null) {
-      getTags(1, 20).then((fetched) => {
+      getTags({ page: 1, limit: 20 }).then((fetched) => {
         const _fetchedTags = Array.isArray(fetched) ? fetched : [];
         setTagsAtom(_fetchedTags);
       });
     }
-  }, [setTagsAtom]);
+  }, [tags, setTagsAtom]);
 
   const setTags = useCallback((newValue: GetTags.Tags[] | null) => {
     setTagsAtom(newValue);
   }, [setTagsAtom]);
 
-  return { tags: tags ?? [], loading, setTags };
+  const refetchTags = useCallback(async ({ page, limit }: { page: number; limit: number }) => {
+    const fetched = await getTags({ page, limit });
+    setTagsAtom(Array.isArray(fetched) ? fetched : []);
+  }, [setTagsAtom]);
+
+  return {
+    tags: tags ?? [],
+    setTags,
+    loading,
+    refetchTags
+  };
 }

--- a/src/requests/get/reviews/index.ts
+++ b/src/requests/get/reviews/index.ts
@@ -24,12 +24,16 @@ export const getReviewByKey = async (
   }
 };
 
-export const getReviews = async (
-  page: number,
-  limit: number
+export const getReviews = async ({
+  page,
+  limit
+}: {
+  limit?: number;
+  page?: number;
+}
 ): Promise<GetReviews.ReviewListItem[] | number> => {
   const response = await fetch(
-    `${BASE_URL}/reviews?page=${page}&limit=${limit}`,
+    `${BASE_URL}/reviews?page=${page ?? 1}&limit=${limit ?? 20}`,
     {
       method: "GET",
       headers: {

--- a/src/requests/get/tags/index.ts
+++ b/src/requests/get/tags/index.ts
@@ -3,12 +3,18 @@ import { GetTags } from "./types";
 const BASE_URL = process.env.NEXT_PUBLIC_API_URL;
 
 export const getTags = async (
-  page: number,
-  limit: number,
-  name?: string
+  {
+    page,
+    limit,
+    name
+  }: {
+    limit?: number;
+    page?: number;
+    name?: string;
+  }
 ): Promise<GetTags.Tags> => {
   try {
-    let url = `${BASE_URL}/tags?page=${page}&limit=${limit}`;
+    let url = `${BASE_URL}/tags?page=${page ?? 1}&limit=${limit ?? 20}`;
 
     if (name) {
       url += "&name=${name}";


### PR DESCRIPTION
# 🚀 Add Parameterized Pagination Support for Map Markers, Reviews, and Tags

**Short description of the change.**

## 📖 Description

- **What’s changing?**  
  This PR introduces support for parameterized pagination to the `useMapMarkers`, `useReviews`, and `useTags` hooks by updating them to use pagination parameters. Functions now include a `refetch` method with customizable pagination options.

- **Why?**  
  To improve flexibility and functionality by allowing consumers of the hooks to specify the page number and limit for fetching data, supporting future scalability and providing a better user experience.

## 🛠 Implementation Details

- Added parameter options to `getReviews` and `getTags` functions to accept objects for page and limit, with default values.
- Introduced `refetchMapMarkers`, `refetchReviews`, and `refetchTags` methods with asynchronous capabilities to allow users to refresh data with custom pagination.
- Updated `useEffect` dependencies in hooks to include setter callback functions, ensuring appropriate re-renders.

## 📊 Queries changed

- Updated `getReviews` and `getTags` functions to use object destructuring for parameters, changing how API calls are constructed with added default parameter values.

## ⚙️ New envs

- None.

## 🔗 Related Issues / Tickets

- None.