### PR TITLE
Fix: Hook that list reviews

### DIFF
--- a/src/app/reviews/components/ReviewsContent.tsx
+++ b/src/app/reviews/components/ReviewsContent.tsx
@@ -1,13 +1,10 @@
 "use client";
 
-import { useEffect, useState } from "react";
-
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 
 import { Text } from "@/components/ui/text";
 import { Title } from "@/components/ui/title";
-import Loading from "@/components/loading";
 import { Badge } from "@/components/ui/badge";
 
 import { useReviews } from "@/hooks/use-reviews";

--- a/src/app/reviews/components/ReviewsContent.tsx
+++ b/src/app/reviews/components/ReviewsContent.tsx
@@ -18,27 +18,8 @@ export default function ReviewsContent() {
   const { reviews } = useReviews();
   const router = useRouter();
 
-  const [page] = useState(1);
-  const [limit] = useState(10);
 
-  useEffect(() => {
-    // TO-DO: Implement pagination
-    // const fetchReviews = async () => {
-    //   const response = await getReviews(page, limit);
-    //   if (response === 404) {
-    //     toast.error("You don't have any reviews", {
-    //       description:
-    //         "Don't worrie! Start to rating to build your reviews portfolio.",
-    //     });
-    //   }
-    //   setReviews(Array.isArray(response) ? response : null);
-    // };
-    // fetchReviews();
-  }, [page, limit]);
-
-  if (!reviews || reviews.length === 0) {
-    return <Loading />;
-  }
+  console.log(reviews)
 
   return (
     <Card className="max-w-3xl mx-auto border shadow-sm">

--- a/src/hooks/use-map-markers.ts
+++ b/src/hooks/use-map-markers.ts
@@ -47,7 +47,7 @@ export function useMapMarkers() {
 
     setIsMapMarkersLoading(false);
     setIsLoading(false);
-  }, [setMapMarkersAtom, isMapMarkersLoading, setIsLoading, setIsMapMarkersLoading, setTotalMapMarkers]);
+  }, [setMapMarkersAtom, isMapMarkersLoading, setIsLoading, setIsMapMarkersLoading, setTotalMapMarkers, setMapMarkers]);
 
   return {
     mapMarkers: mapMarkers ?? [],

--- a/src/hooks/use-reviews.ts
+++ b/src/hooks/use-reviews.ts
@@ -25,7 +25,7 @@ export function useReviews() {
       setIsReviewsLoading(true);
       setIsLoading(true);
       getReviews({ page: 1, limit: 20 }).then((fetched) => {
-        setReviews(Array.isArray(fetched) ? fetched : []);
+        setReviews(Array.isArray(fetched.data) ? fetched.data : []);
         setTotalReviews(fetched.total);
       }).finally(() => {
         setIsReviewsLoading(false);
@@ -41,7 +41,7 @@ export function useReviews() {
     setIsLoading(true);
 
     const fetched = await getReviews({ page, limit });
-    setReviews(Array.isArray(fetched) ? fetched : []);
+    setReviews(Array.isArray(fetched.data) ? fetched.data : []);
     setTotalReviews(fetched.total);
 
     setIsReviewsLoading(false);

--- a/src/hooks/use-reviews.ts
+++ b/src/hooks/use-reviews.ts
@@ -32,7 +32,7 @@ export function useReviews() {
         setIsLoading(false);
       });
     }
-  }, [reviews, setReviews, isReviewsLoading, setIsLoading, setIsReviewsLoading]);
+  }, [reviews, setReviews, isReviewsLoading, setIsLoading, setIsReviewsLoading, setTotalReviews]);
 
   const refetchReviews = useCallback(async ({ page, limit }: { page: number; limit: number }) => {
     if (isReviewsLoading) return;
@@ -46,7 +46,7 @@ export function useReviews() {
 
     setIsReviewsLoading(false);
     setIsLoading(false);
-  }, [setReviewsAtom, isReviewsLoading, setIsLoading, setIsReviewsLoading]);
+  }, [setReviewsAtom, isReviewsLoading, setIsLoading, setIsReviewsLoading, setReviews, setTotalReviews]);
 
   return {
     reviews: reviews ?? [],


### PR DESCRIPTION
# 🚀 Fix: Hook that list reviews

Remove unnecessary imports and add dependency lists to useEffects for improved efficiency

## 📖 Description

- **What’s changing?**  
  This PR removes unused imports and enhances the efficiency of `useEffect` dependencies in the `ReviewsContent` and custom hooks.

- **Why?**  
  The changes were made to clean up the code by removing unused imports, improving the performance by ensuring the dependency lists of `useEffect` are complete, and preparing for potential future improvements in pagination.

## 🛠 Implementation Details

- Removed unused `useEffect`, `useState`, and `Loading` imports from `ReviewsContent.tsx`.
- Removed pagination logic placeholder in `ReviewsContent.tsx` to keep the component clean.
- Updated `useEffect` dependency lists in `use-map-markers.ts` and `use-reviews.ts`:
  - Added missing dependencies to ensure side effects are correctly managed.
- Changed data access in `useReviews` to `fetched.data` for clarity and consistency.

## 📊 Queries changed

- Adjusted data handling in `useReviews` to access `fetched.data` instead of `fetched`.

## ⚙️ New envs

- None

## 🔗 Related Issues / Tickets

- None